### PR TITLE
Fix comment about commit message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ server.tool("git.updateBranch",
     currentWorkingDirectory: z.string(),
    },
   async ({ fullPrompt, chatId, changesSummary, currentWorkingDirectory }) => {
-    // Use the promptSummary as the commit message
+    // Verwende fullPrompt als Commit-Nachricht
     const result = await Git.updateBranch(currentWorkingDirectory, fullPrompt, changesSummary, chatId, true);
     
     if (result.success) {


### PR DESCRIPTION
## Summary
- clarify that `fullPrompt` is used for commit messages in the git.updateBranch tool
- translate the comment to German

## Testing
- `npm run jest` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_683961fed4a4832aa487a65acdeb89c6